### PR TITLE
RDKE-127: Add systemd distro check for rpi_generate_sysctl_config

### DIFF
--- a/recipes-core/images/middleware-generic-test-image.bbappend
+++ b/recipes-core/images/middleware-generic-test-image.bbappend
@@ -1,0 +1,17 @@
+ROOTFS_POSTPROCESS_COMMAND_remove = " rpi_generate_sysctl_config ; "
+ROOTFS_POSTPROCESS_COMMAND += " rpi_generate_systemd_config ; "
+
+rpi_generate_systemd_config() {
+    if [ "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}" = "true" ]
+    then
+         # systemd sysctl config
+         test -d ${IMAGE_ROOTFS}${sysconfdir}/sysctl.d && \
+             echo "vm.min_free_kbytes = 8192" > ${IMAGE_ROOTFS}${sysconfdir}/sysctl.d/rpi-vm.conf
+    else
+         # sysv sysctl config
+         IMAGE_SYSCTL_CONF="${IMAGE_ROOTFS}${sysconfdir}/sysctl.conf"
+         test -e ${IMAGE_ROOTFS}${sysconfdir}/sysctl.conf && \
+             sed -e "/vm.min_free_kbytes/d" -i ${IMAGE_SYSCTL_CONF}
+         echo "" >> ${IMAGE_SYSCTL_CONF} && echo "vm.min_free_kbytes = 8192" >> ${IMAGE_SYSCTL_CONF}
+    fi
+}


### PR DESCRIPTION
Reason for change: As per RDK-45498, no individual component must install their own sysctl conf files into /etc/sysctl.conf , allowing that can potentially override other settings. Components can install the conf in /etc/sysctl.d/ path.

Fix is to override the rpi_generate_sysctl_config function in sdcard_image-rpi.bbclass in meta-raspberrypi with rpi_generate_systemd_config, check for systemd DISTRO_FEATURES first.

Test Procedure: Ensure build is success
Risks: Medium