### PR TITLE
RDKVREFPLT-3151: fix the symlink issue

### DIFF
--- a/recipes-halif/mfrlibs/mfrlibs-hal-raspberrypi4.bb
+++ b/recipes-halif/mfrlibs/mfrlibs-hal-raspberrypi4.bb
@@ -19,7 +19,7 @@ do_install:append() {
     # Provide FlashApp support
     install -d ${D}${bindir}
     install -m 0755 ${S}/FlashApp.sh ${D}${bindir}/FlashApp.sh
-    ln -sf ${D}${bindir}/FlashApp.sh ${D}${bindir}/FlashApp
+    ln -sf FlashApp.sh ${D}${bindir}/FlashApp
 }
 
 FILES:${PN} += "${bindir}/*"

--- a/recipes-halif/mfrlibs/mfrlibs-hal-raspberrypi4.bb
+++ b/recipes-halif/mfrlibs/mfrlibs-hal-raspberrypi4.bb
@@ -19,7 +19,7 @@ do_install:append() {
     # Provide FlashApp support
     install -d ${D}${bindir}
     install -m 0755 ${S}/FlashApp.sh ${D}${bindir}/FlashApp.sh
-    ln -sf FlashApp.sh ${D}${bindir}/FlashApp
+    ln -sr ${D}${bindir}/FlashApp.sh ${D}${bindir}/FlashApp
 }
 
 FILES:${PN} += "${bindir}/*"


### PR DESCRIPTION
Default change is point to a wrong one
```
root@raspberrypi4-64-rdke:~# ls -aslh /usr/bin/ | grep Flash
     4 lrwxrwxrwx    1 root     root         202 Mar  9  2018 FlashApp -> /mnt/jenkins/workspace/RASPBERRYPI-VENDOR-Build/build-raspberrypi4-64-rdke/tmp/work/raspberrypi4-64-rdke-vendor-rdkmllib32-linux-gnueabi/lib32-mfrlibs-hal-raspberrypi4/1.0.3-r0/image/usr/bin/FlashApp.sh
    12 -rwxr-xr-x    1 root     root       10.7K Mar  9  2018 FlashApp.sh
root@raspberrypi4-64-rdke:~#
```
With this change; it shall point to correct file in rootfs.