### PR TITLE
RDKVREFPLTV-4051: rename pkggrp version to v4.0.1

### DIFF
--- a/recipes-core/packagegroups/packagegroup-vendor-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-vendor-layer.bb
@@ -8,7 +8,7 @@ inherit packagegroup
 
 DEPENDS = " virtual/kernel make-mod-scripts"
 
-PV = "1.2.8"
+PV = "4.0.1"
 PR = "r0"
 
 RDEPENDS:${PN} = " \


### PR DESCRIPTION
Update and align the vendor package version to v4.0.1 conveying Kirkstone support.