### PR TITLE
Change vendor pkggrp version - PV to 4.0.1

### DIFF
--- a/recipes-core/packagegroups/packagegroup-vendor-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-vendor-layer.bb
@@ -8,7 +8,7 @@ inherit packagegroup
 
 DEPENDS = " virtual/kernel make-mod-scripts"
 
-PV = "1.2.7"
+PV = "1.2.8"
 PR = "r0"
 
 RDEPENDS:${PN} = " \

--- a/recipes-core/packagegroups/packagegroup-vendor-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-vendor-layer.bb
@@ -8,7 +8,7 @@ inherit packagegroup
 
 DEPENDS = " virtual/kernel make-mod-scripts"
 
-PV = "1.2.8"
+PV = "4.0.1"
 PR = "r0"
 
 RDEPENDS:${PN} = " \


### PR DESCRIPTION
To convey kirkstone alignment and vedor releases; renamed vendor pkg version to 4.0.1