### PR TITLE
Revert PWRMGRHAL to v1.1.0

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -194,8 +194,8 @@ PV:pn-iarmmgrs-hal-raspberrypi4 = "2.0.1"
 PR:pn-iarmmgrs-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-iarmmgrs-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-pwrmgr-hal-raspberrypi4 = "f559dd23838db9cc20cfba5513a1afa9db4525c2"
-PV:pn-pwrmgr-hal-raspberrypi4 = "1.1.1"
+SRCREV:pn-pwrmgr-hal-raspberrypi4 = "4781328b379ce4d88084ec75ca714733212fad40"
+PV:pn-pwrmgr-hal-raspberrypi4 = "1.1.0"
 PR:pn-pwrmgr-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-pwrmgr-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 


### PR DESCRIPTION
Reason for Change: with v1.1.1 MW image reboots continuously. Revert to known good version.