### PR TITLE
RDKVREFPLT-4254: sysint-soc repo release 1.1.0

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -209,8 +209,8 @@ PV:pn-mfrlibs-hal-raspberrypi4 = "1.1.0"
 PR:pn-mfrlibs-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-mfrlibs-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-sysint-soc = "6bfd58ede41fc0a8f62e201f8a386e7f41a51553"
-PV:pn-sysint-soc = "1.0.4"
+SRCREV:pn-sysint-soc = "c892d8f59b42077a93455737c77d50de3ff48115"
+PV:pn-sysint-soc = "1.1.0"
 PR:pn-sysint-soc = "r0"
 PACKAGE_ARCH:pn-sysint-soc = "${VENDOR_LAYER_EXTENSION}"
 


### PR DESCRIPTION
Reason for change: Cold launch of Xumo takes morethan 10 seconds. Set wayland compositor type as surface in wpeframework drop-in conf