### PR TITLE
REFPLTV-2609: Audio not heard for AC3 and EAC3 streams

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -238,3 +238,7 @@ SRCREV:pn-secapi2-adapter-rpi  = "1.0"
 PV:pn-secapi2-adapter-rpi  = "1.0"
 PR:pn-secapi2-adapter-rpi  = "r0"
 PACKAGE_ARCH:pn-secapi2-adapter-rpi  = "${VENDOR_LAYER_EXTENSION}"
+
+PREFERRED_VERSION_ffmpeg = "4.2.2"
+PR:pn-ffmpeg = "r1"
+PACKAGE_ARCH:pn-ffmpeg = "${VENDOR_LAYER_EXTENSION}"

--- a/recipes-core/packagegroups/packagegroup-vendor-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-vendor-layer.bb
@@ -12,6 +12,7 @@ PV = "4.0.5"
 PR = "r0"
 
 RDEPENDS:${PN} = " \
+        ffmpeg \
         pi-bluetooth \
         sysint-soc \
         systemaudioplatform \


### PR DESCRIPTION
Reason for change: Enabling ac3 decoders in ffmpeg Test Procedure: Play ac3 streams using gst launch
Risks:High
Priority: P1