### PR TITLE
RDKE-635 Fix unused variable in tr69hostif: warning seen in only raspberrypi platform

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -179,7 +179,7 @@ PACKAGE_ARCH:pn-wayland-default-egl = "${VENDOR_LAYER_EXTENSION}"
 # RDKV HAL component versions
 
 # RDKV HAL component versions of raspberrypi4
-SRCREV:pn-devicesettings-hal-raspberrypi4 = "b57681736e88a71fad9b9a0e50f18042e3065c49"
+SRCREV:pn-devicesettings-hal-raspberrypi4 = "377ab7281c0cc3d7a0c5f7b2c76b449ceabaf602"
 PV:pn-devicesettings-hal-raspberrypi4 = "1.0.8"
 PR:pn-devicesettings-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-devicesettings-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"


### PR DESCRIPTION
Reason for change: Improve tr69hostif module code stability
Test Procedure: Sanity, functionality tests
Risks: None
Priority: P2
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)