### PR TITLE
REFPLTV-2503 : hls support for RPI

### DIFF
--- a/recipes-multimedia/gstreamer1.0_1.18/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer1.0_1.18/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,0 +1,2 @@
+#This is a workaround since hls is already removed
+EXTRA_OEMESON:append = " -Dhls=enabled"


### PR DESCRIPTION
Reason for change: HLS support for gstreamer playback
Test Procedure: Sanity, functionality tests
Risks: None
Priority: P1