### PR TITLE
REFPLTV-2609, REFPLTV-2594: update ffmpeg and sysint-soc to latest in main

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -209,8 +209,8 @@ PV:pn-mfrlibs-hal-raspberrypi4 = "1.1.0"
 PR:pn-mfrlibs-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-mfrlibs-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-sysint-soc = "7202fb64f27adbf0bf4e70cc65a1c0ec75c17556"
-PV:pn-sysint-soc = "1.1.0"
+SRCREV:pn-sysint-soc = "ebf97324a74f0e2f689d804103d6986074cbb332"
+PV:pn-sysint-soc = "1.1.2"
 PR:pn-sysint-soc = "r0"
 PACKAGE_ARCH:pn-sysint-soc = "${VENDOR_LAYER_EXTENSION}"
 

--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -238,3 +238,7 @@ SRCREV:pn-secapi2-adapter-rpi  = "1.0"
 PV:pn-secapi2-adapter-rpi  = "1.0"
 PR:pn-secapi2-adapter-rpi  = "r0"
 PACKAGE_ARCH:pn-secapi2-adapter-rpi  = "${VENDOR_LAYER_EXTENSION}"
+
+PREFERRED_VERSION_ffmpeg = "4.2.2"
+PR:pn-ffmpeg = "r1"
+PACKAGE_ARCH:pn-ffmpeg = "${VENDOR_LAYER_EXTENSION}"

--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -209,8 +209,8 @@ PV:pn-mfrlibs-hal-raspberrypi4 = "1.1.0"
 PR:pn-mfrlibs-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-mfrlibs-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-sysint-soc = "ebf97324a74f0e2f689d804103d6986074cbb332"
-PV:pn-sysint-soc = "1.1.2"
+SRCREV:pn-sysint-soc = "689e7b54ccf0e76d273da1565a5c87e972814b7d"
+PV:pn-sysint-soc = "1.1.3"
 PR:pn-sysint-soc = "r0"
 PACKAGE_ARCH:pn-sysint-soc = "${VENDOR_LAYER_EXTENSION}"
 

--- a/recipes-core/packagegroups/packagegroup-vendor-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-vendor-layer.bb
@@ -12,6 +12,7 @@ PV = "4.0.5"
 PR = "r0"
 
 RDEPENDS:${PN} = " \
+        ffmpeg \
         pi-bluetooth \
         sysint-soc \
         systemaudioplatform \

--- a/recipes-core/packagegroups/packagegroup-vendor-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-vendor-layer.bb
@@ -8,7 +8,7 @@ inherit packagegroup
 
 DEPENDS = " virtual/kernel make-mod-scripts"
 
-PV = "4.0.4"
+PV = "4.0.5"
 PR = "r0"
 
 RDEPENDS:${PN} = " \


### PR DESCRIPTION
- [REFPLTV-2609: Audio not heard for AC3 and EAC3 streams](https://github.com/rdkcentral/meta-vendor-raspberrypi-dev/commit/5c7e9621b88e3b871bcdf30a4d5a547952dafa1e). ffmpeg added as VENDOR_LAYER_EXTENSION
- [REFPLTV-2594: sysint-soc update to v1.1.3](https://github.com/rdkcentral/meta-vendor-raspberrypi-dev/commit/241b0c328e53884e72a5ef97d561078398b999e4)