### PR TITLE
RDK7RM-15: Fix Nothing provides /bin/bash in userland

### DIFF
--- a/recipes-graphics/userland/userland_git.bbappend
+++ b/recipes-graphics/userland/userland_git.bbappend
@@ -39,4 +39,4 @@ FILES:${PN}:append = "\
 RPROVIDES:${PN}:remove = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', 'libegl', '', d)}"
 
 # Fix do_package_qa err
-INSANE_SKIP:${PN}-dev = " staticdev"
+INSANE_SKIP:${PN}-dev = " staticdev file-rdeps "


### PR DESCRIPTION
/bin/bash is a symlink to /bin/bash.bash, which is provided by lib32-bash from OSS.