### PR TITLE
REFPLTV-2927: Vendor release 4.4.6

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -184,8 +184,8 @@ PV:pn-devicesettings-hal-raspberrypi4 = "1.1.2"
 PR:pn-devicesettings-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-devicesettings-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-hdmicec-hal-raspberrypi4 = "1.0.2"
-PV:pn-hdmicec-hal-raspberrypi4 = "1.0.2"
+SRCREV:pn-hdmicec-hal-raspberrypi4 = "1.0.3"
+PV:pn-hdmicec-hal-raspberrypi4 = "1.0.3"
 PR:pn-hdmicec-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-hdmicec-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
@@ -209,8 +209,8 @@ PV:pn-mfrlibs-hal-raspberrypi4 = "1.1.0"
 PR:pn-mfrlibs-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-mfrlibs-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-sysint-soc = "1.1.5"
-PV:pn-sysint-soc = "1.1.5"
+SRCREV:pn-sysint-soc = "1.1.6"
+PV:pn-sysint-soc = "1.1.6"
 PR:pn-sysint-soc = "r0"
 PACKAGE_ARCH:pn-sysint-soc = "${VENDOR_LAYER_EXTENSION}"
 
@@ -219,8 +219,8 @@ PV:pn-systemaudioplatform = "1.0.0"
 PR:pn-systemaudioplatform = "r0"
 PACKAGE_ARCH:pn-systemaudioplatform = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-rdk-gstreamer-utils-platform = "1.0.1"
-PV:pn-rdk-gstreamer-utils-platform = "1.0.1"
+SRCREV:pn-rdk-gstreamer-utils-platform = "1.0.0"
+PV:pn-rdk-gstreamer-utils-platform = "1.0.0"
 PR:pn-rdk-gstreamer-utils-platform = "r0"
 PACKAGE_ARCH:pn-rdk-gstreamer-utils-platform = "${VENDOR_LAYER_EXTENSION}"
 

--- a/recipes-core/packagegroups/packagegroup-vendor-layer.bb
+++ b/recipes-core/packagegroups/packagegroup-vendor-layer.bb
@@ -8,7 +8,7 @@ inherit packagegroup
 
 DEPENDS = " virtual/kernel make-mod-scripts"
 
-PV = "4.4.4"
+PV = "4.4.6"
 PR = "r0"
 
 RDEPENDS:${PN} = " \


### PR DESCRIPTION
REFPLTV-2927: Vendor release 4.4.6
Fixes 
1] Toggling of cec control causes wpeframework crash
2] oem-first-boot.service not completing activation until internet is available.
3] Correct rdk-gstreamer-utils release tag to match with halif-headers