### PR TITLE
RDKVREFPLT-6196 [RPI] Vendor layer update 3.0.0 tag

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -179,7 +179,7 @@ PACKAGE_ARCH:pn-wayland-default-egl = "${VENDOR_LAYER_EXTENSION}"
 # RDKV HAL component versions
 
 # RDKV HAL component versions of raspberrypi4
-SRCREV:pn-devicesettings-hal-raspberrypi4 = "1.1.2"
+SRCREV:pn-devicesettings-hal-raspberrypi4 = "5b0176b2f2f9d24096efcd79f607b42bb29cfe65"
 PV:pn-devicesettings-hal-raspberrypi4 = "1.1.2"
 PR:pn-devicesettings-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-devicesettings-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
@@ -188,6 +188,11 @@ SRCREV:pn-hdmicec-hal-raspberrypi4 = "1.0.3"
 PV:pn-hdmicec-hal-raspberrypi4 = "1.0.3"
 PR:pn-hdmicec-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-hdmicec-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
+
+SRCREV:pn-iarmmgrs-hal-raspberrypi4 = "1.0.0"
+PV:pn-iarmmgrs-hal-raspberrypi4 = "2.0.1"
+PR:pn-iarmmgrs-hal-raspberrypi4 = "r0"
+PACKAGE_ARCH:pn-iarmmgrs-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
 SRCREV:pn-pwrmgr-hal-raspberrypi4 = "1.2.0"
 PV:pn-pwrmgr-hal-raspberrypi4 = "1.2.0"
@@ -214,7 +219,7 @@ PV:pn-systemaudioplatform = "1.0.0"
 PR:pn-systemaudioplatform = "r0"
 PACKAGE_ARCH:pn-systemaudioplatform = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-rdk-gstreamer-utils-platform = "1.0.1"
+SRCREV:pn-rdk-gstreamer-utils-platform = "bd70a1c8d0c2b5aef6e761104e6721b6d60e6a68"
 PV:pn-rdk-gstreamer-utils-platform = "1.0.1"
 PR:pn-rdk-gstreamer-utils-platform = "r0"
 PACKAGE_ARCH:pn-rdk-gstreamer-utils-platform = "${VENDOR_LAYER_EXTENSION}"

--- a/recipes-core/packagegroups/packagegroup-hal-raspberrypi4.bb
+++ b/recipes-core/packagegroups/packagegroup-hal-raspberrypi4.bb
@@ -4,12 +4,13 @@ LICENSE = "MIT"
 
 PACKAGE_ARCH = "${VENDOR_LAYER_EXTENSION}"
 
-inherit packagegroup
+inherit packagegroup hal-version
 
 PV = "1.0.1"
 PR = "r0"
 
 RDEPENDS:${PN} = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'rdk-iarmmgrs-hal-unified-v1.0.1', 'iarmmgrs-hal-raspberrypi4', '', d)} \
     devicesettings-hal-raspberrypi4 \
     hdmicec-hal-raspberrypi4 \
     pwrmgr-hal-raspberrypi4 \

--- a/recipes-halif/devicesettings/devicesettings-hal-raspberrypi4.bb
+++ b/recipes-halif/devicesettings/devicesettings-hal-raspberrypi4.bb
@@ -43,7 +43,15 @@ FILES_SOLIBSDEV = ""
 INSANE_SKIP:${PN} += "dev-so"
 
 #inherit coverity systemd pkgconfig
-inherit systemd cmake pkgconfig
+inherit systemd cmake pkgconfig hal-version
+
+CFLAGS += " -Wno-unused-parameter"
+
+CFLAGS += " \
+  -DRDK_HALIF_DEVICE_SETTINGS_VERSION_MAJOR=${DEVICE_SETTINGS_VER_MAJOR} \
+  -DRDK_HALIF_DEVICE_SETTINGS_VERSION_MINOR=${DEVICE_SETTINGS_VER_MINOR} \
+  -DRDK_HALIF_DEVICE_SETTINGS_VERSION_BUILD=${DEVICE_SETTINGS_VER_BUILD} \
+  -DRDK_HALIF_DEVICE_SETTINGS_VERSION_ENGINEERING=${DEVICE_SETTINGS_VER_ENG}"
 
 do_install:append() {
     install -d ${D}${bindir}

--- a/recipes-halif/iarmmgrs/iarmmgrs-hal-raspberrypi4.bb
+++ b/recipes-halif/iarmmgrs/iarmmgrs-hal-raspberrypi4.bb
@@ -1,0 +1,22 @@
+DESCRIPTION = "IARMMGRS HAL Implementation - IR"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b1e01b26bacfc2232046c90a330332b3"
+
+PROVIDES = "virtual/iarmmgrs-hal virtual/vendor-iarmmgrs-hal"
+RPROVIDES:${PN} = "virtual/iarmmgrs-hal virtual/vendor-iarmmgrs-hal"
+
+SRC_URI = "${CMF_GITHUB_ROOT}/rdkvhal-ir-manager-raspberrypi4;${CMF_GIT_SRC_URI_SUFFIX}"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "iarmmgrs-hal-headers iarmbus-headers"
+
+inherit autotools coverity
+
+CFLAGS += " \
+    -I${STAGING_DIR_TARGET}${includedir}/rdk/iarmmgrs-hal/ \
+    "
+
+FILES:${PN} += "${libdir}/*.so"
+FILES_SOLIBSDEV = ""
+INSANE_SKIP:${PN} += "dev-so"

--- a/recipes-soc/rdk-gstreamer-utils-platform/rdk-gstreamer-utils-platform.bb
+++ b/recipes-soc/rdk-gstreamer-utils-platform/rdk-gstreamer-utils-platform.bb
@@ -11,7 +11,13 @@ RPROVIDES:${PN} = "virtual/vendor-rdk-gstreamer-utils-platform"
 
 CXXFLAGS += "-I${STAGING_INCDIR}/glib-2.0 -I${STAGING_INCDIR}/gstreamer-1.0 -I${STAGING_DIR_TARGET}/${libdir}/glib-2.0/include/ "
 
-inherit autotools pkgconfig
+inherit autotools pkgconfig hal-version
+
+CXXFLAGS += " \
+  -DRDK_HALIF_RDK_GSTREAMER_VERSION_MAJOR=${RDK_GSTREAMER_VER_MAJOR} \
+  -DRDK_HALIF_RDK_GSTREAMER_VERSION_MINOR=${RDK_GSTREAMER_VER_MINOR} \
+  -DRDK_HALIF_RDK_GSTREAMER_VERSION_BUILD=${RDK_GSTREAMER_VER_BUILD} \
+  -DRDK_HALIF_RDK_GSTREAMER_VERSION_ENGINEERING=${RDK_GSTREAMER_VER_ENG}"
 
 do_compile () {
     oe_runmake -C ${S} -f Makefile


### PR DESCRIPTION
Reason for change: Added changes to support halif 1.0.3, 2.0.2 and 3.0.0 revisions

Test Procedure: Build and verify