### PR TITLE
RDKEVL-4433: [RPI]Update the rdk-gstreamer-utils-platform and devicesettings-hal-raspberrypi4 recipe SRC_REV version.

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -179,8 +179,8 @@ PACKAGE_ARCH:pn-wayland-default-egl = "${VENDOR_LAYER_EXTENSION}"
 # RDKV HAL component versions
 
 # RDKV HAL component versions of raspberrypi4
-SRCREV:pn-devicesettings-hal-raspberrypi4 = "5b0176b2f2f9d24096efcd79f607b42bb29cfe65"
-PV:pn-devicesettings-hal-raspberrypi4 = "1.1.2"
+SRCREV:pn-devicesettings-hal-raspberrypi4 = "1.2.0"
+PV:pn-devicesettings-hal-raspberrypi4 = "1.2.0"
 PR:pn-devicesettings-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-devicesettings-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 
@@ -219,8 +219,8 @@ PV:pn-systemaudioplatform = "1.0.0"
 PR:pn-systemaudioplatform = "r0"
 PACKAGE_ARCH:pn-systemaudioplatform = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-rdk-gstreamer-utils-platform = "bd70a1c8d0c2b5aef6e761104e6721b6d60e6a68"
-PV:pn-rdk-gstreamer-utils-platform = "1.0.1"
+SRCREV:pn-rdk-gstreamer-utils-platform = "1.1.0"
+PV:pn-rdk-gstreamer-utils-platform = "1.1.0"
 PR:pn-rdk-gstreamer-utils-platform = "r0"
 PACKAGE_ARCH:pn-rdk-gstreamer-utils-platform = "${VENDOR_LAYER_EXTENSION}"
 


### PR DESCRIPTION
**Reason for change:** Update the rdk-gstreamer-utils-platform and devicesettings-hal-raspberrypi4 recipe SRC_REV version.
**Risks:** High.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com