### PR TITLE
RDKEVL-6499 - [RPI][3.0.2] Halif version update

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -224,8 +224,8 @@ PV:pn-systemaudioplatform = "1.0.1"
 PR:pn-systemaudioplatform = "r0"
 PACKAGE_ARCH:pn-systemaudioplatform = "${VENDOR_LAYER_EXTENSION}"
 
-SRCREV:pn-rdk-gstreamer-utils-platform = "1.1.0"
-PV:pn-rdk-gstreamer-utils-platform = "1.1.0"
+SRCREV:pn-rdk-gstreamer-utils-platform = "1.2.0"
+PV:pn-rdk-gstreamer-utils-platform = "1.2.0"
 PR:pn-rdk-gstreamer-utils-platform = "r0"
 PACKAGE_ARCH:pn-rdk-gstreamer-utils-platform = "${VENDOR_LAYER_EXTENSION}"
 


### PR DESCRIPTION
Reason for change: Updated the SRCREV for the rdk-gstreamer-utils-platform component.

Test Procedure: Verify the build.

Risks: Low

Signed-off-by: thenmozhi_kathiravan@comcast.com