### PR TITLE
RDKMVE-2015, RDKMVE-2155: potential misconfiguration fix for device.properties

### DIFF
--- a/recipes-soc/sysint-soc/sysint-soc.bb
+++ b/recipes-soc/sysint-soc/sysint-soc.bb
@@ -17,16 +17,18 @@ SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
 # Overlay build-configuration values from the product layer where property keys match.
 update_device_properties() {
+    # Escape characters special to sed replacement text (\, &, and the | delimiter).
+    escape_sed_replacement() { printf '%s' "$1" | sed 's/[&|\\]/\\&/g'; }
     props="${D}${sysconfdir}/device-vendor.properties"
     # Normalize line endings (CRLF -> LF) and ensure a trailing newline.
     sed -i 's/\r$//' "$props"
     [ -n "$(tail -c1 "$props")" ] && echo >> "$props"
-    # Replace the matching ones.
-    [ -n "${DEVICE_MODEL_NUMBER}" ] && sed -i "s|^MODEL_NUM=.*|MODEL_NUM=${DEVICE_MODEL_NUMBER}|" "$props"
-    [ -n "${DAC_APP_PATH}" ] && sed -i "s|^DAC_APP_PATH=.*|DAC_APP_PATH=${DAC_APP_PATH}|" "$props"
-    [ -n "${APP_PREINSTALL_DIRECTORY}" ] && sed -i "s|^APP_PREINSTALL_DIRECTORY=.*|APP_PREINSTALL_DIRECTORY=${APP_PREINSTALL_DIRECTORY}|" "$props"
-    [ -n "${APP_DOWNLOAD_DIRECTORY}" ] && sed -i "s|^APP_DOWNLOAD_DIRECTORY=.*|APP_DOWNLOAD_DIRECTORY=${APP_DOWNLOAD_DIRECTORY}|" "$props"
-    [ -n "${DEFAULT_APP_STORAGE_PATH}" ] && sed -i "s|^DEFAULT_APP_STORAGE_PATH=.*|DEFAULT_APP_STORAGE_PATH=${DEFAULT_APP_STORAGE_PATH}|" "$props"
+    # Replace the matching ones, escaping sed-special characters in the values.
+    [ -n "${DEVICE_MODEL_NUMBER}" ] && escaped_value="$(escape_sed_replacement "${DEVICE_MODEL_NUMBER}")" && sed -i "s|^MODEL_NUM=.*|MODEL_NUM=$escaped_value|" "$props"
+    [ -n "${DAC_APP_PATH}" ] && escaped_value="$(escape_sed_replacement "${DAC_APP_PATH}")" && sed -i "s|^DAC_APP_PATH=.*|DAC_APP_PATH=$escaped_value|" "$props"
+    [ -n "${APP_PREINSTALL_DIRECTORY}" ] && escaped_value="$(escape_sed_replacement "${APP_PREINSTALL_DIRECTORY}")" && sed -i "s|^APP_PREINSTALL_DIRECTORY=.*|APP_PREINSTALL_DIRECTORY=$escaped_value|" "$props"
+    [ -n "${APP_DOWNLOAD_DIRECTORY}" ] && escaped_value="$(escape_sed_replacement "${APP_DOWNLOAD_DIRECTORY}")" && sed -i "s|^APP_DOWNLOAD_DIRECTORY=.*|APP_DOWNLOAD_DIRECTORY=$escaped_value|" "$props"
+    [ -n "${DEFAULT_APP_STORAGE_PATH}" ] && escaped_value="$(escape_sed_replacement "${DEFAULT_APP_STORAGE_PATH}")" && sed -i "s|^DEFAULT_APP_STORAGE_PATH=.*|DEFAULT_APP_STORAGE_PATH=$escaped_value|" "$props"
 }
 
 do_install() {

--- a/recipes-soc/sysint-soc/sysint-soc.bb
+++ b/recipes-soc/sysint-soc/sysint-soc.bb
@@ -19,16 +19,28 @@ SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 update_device_properties() {
     # Escape characters special to sed replacement text (\, &, and the | delimiter).
     escape_sed_replacement() { printf '%s' "$1" | sed 's/[&|\\]/\\&/g'; }
+
+    # Update a single key=value line in the properties file.
+    replace_prop() {
+        prop_key="$1"
+        prop_value="$2"
+        [ -n "$prop_value" ] || return 0
+        escaped_value="$(escape_sed_replacement "$prop_value")"
+        sed -i "s|^${prop_key}=.*|${prop_key}=$escaped_value|" "$props"
+    }
+
     props="${D}${sysconfdir}/device-vendor.properties"
+
     # Normalize line endings (CRLF -> LF) and ensure a trailing newline.
     sed -i 's/\r$//' "$props"
     [ -n "$(tail -c1 "$props")" ] && echo >> "$props"
-    # Replace the matching ones, escaping sed-special characters in the values.
-    [ -n "${DEVICE_MODEL_NUMBER}" ] && escaped_value="$(escape_sed_replacement "${DEVICE_MODEL_NUMBER}")" && sed -i "s|^MODEL_NUM=.*|MODEL_NUM=$escaped_value|" "$props"
-    [ -n "${DAC_APP_PATH}" ] && escaped_value="$(escape_sed_replacement "${DAC_APP_PATH}")" && sed -i "s|^DAC_APP_PATH=.*|DAC_APP_PATH=$escaped_value|" "$props"
-    [ -n "${APP_PREINSTALL_DIRECTORY}" ] && escaped_value="$(escape_sed_replacement "${APP_PREINSTALL_DIRECTORY}")" && sed -i "s|^APP_PREINSTALL_DIRECTORY=.*|APP_PREINSTALL_DIRECTORY=$escaped_value|" "$props"
-    [ -n "${APP_DOWNLOAD_DIRECTORY}" ] && escaped_value="$(escape_sed_replacement "${APP_DOWNLOAD_DIRECTORY}")" && sed -i "s|^APP_DOWNLOAD_DIRECTORY=.*|APP_DOWNLOAD_DIRECTORY=$escaped_value|" "$props"
-    [ -n "${DEFAULT_APP_STORAGE_PATH}" ] && escaped_value="$(escape_sed_replacement "${DEFAULT_APP_STORAGE_PATH}")" && sed -i "s|^DEFAULT_APP_STORAGE_PATH=.*|DEFAULT_APP_STORAGE_PATH=$escaped_value|" "$props"
+
+    # Replace the matching ones; BitBake expands ${VAR} at parse time before the shell runs.
+    replace_prop MODEL_NUM "${DEVICE_MODEL_NUMBER}"
+    replace_prop DAC_APP_PATH "${DAC_APP_PATH}"
+    replace_prop APP_PREINSTALL_DIRECTORY "${APP_PREINSTALL_DIRECTORY}"
+    replace_prop APP_DOWNLOAD_DIRECTORY "${APP_DOWNLOAD_DIRECTORY}"
+    replace_prop DEFAULT_APP_STORAGE_PATH "${DEFAULT_APP_STORAGE_PATH}"
 }
 
 do_install() {

--- a/recipes-soc/sysint-soc/sysint-soc.bb
+++ b/recipes-soc/sysint-soc/sysint-soc.bb
@@ -18,6 +18,10 @@ SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 # Overlay build-configuration values from the product layer where property keys match.
 update_device_properties() {
     props="${D}${sysconfdir}/device-vendor.properties"
+    # Normalize line endings (CRLF -> LF) and ensure a trailing newline.
+    sed -i 's/\r$//' "$props"
+    [ -n "$(tail -c1 "$props")" ] && echo >> "$props"
+    # Replace the matching ones.
     [ -n "${DEVICE_MODEL_NUMBER}" ] && sed -i "s|^MODEL_NUM=.*|MODEL_NUM=${DEVICE_MODEL_NUMBER}|" "$props"
     [ -n "${DAC_APP_PATH}" ] && sed -i "s|^DAC_APP_PATH=.*|DAC_APP_PATH=${DAC_APP_PATH}|" "$props"
     [ -n "${APP_PREINSTALL_DIRECTORY}" ] && sed -i "s|^APP_PREINSTALL_DIRECTORY=.*|APP_PREINSTALL_DIRECTORY=${APP_PREINSTALL_DIRECTORY}|" "$props"

--- a/recipes-soc/sysint-soc/sysint-soc.bb
+++ b/recipes-soc/sysint-soc/sysint-soc.bb
@@ -15,6 +15,16 @@ do_compile[noexec] = "1"
 
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"
 
+# Overlay build-configuration values from the product layer where property keys match.
+update_device_properties() {
+    props="${D}${sysconfdir}/device-vendor.properties"
+    [ -n "${DEVICE_MODEL_NUMBER}" ] && sed -i "s|^MODEL_NUM=.*|MODEL_NUM=${DEVICE_MODEL_NUMBER}|" "$props"
+    [ -n "${DAC_APP_PATH}" ] && sed -i "s|^DAC_APP_PATH=.*|DAC_APP_PATH=${DAC_APP_PATH}|" "$props"
+    [ -n "${APP_PREINSTALL_DIRECTORY}" ] && sed -i "s|^APP_PREINSTALL_DIRECTORY=.*|APP_PREINSTALL_DIRECTORY=${APP_PREINSTALL_DIRECTORY}|" "$props"
+    [ -n "${APP_DOWNLOAD_DIRECTORY}" ] && sed -i "s|^APP_DOWNLOAD_DIRECTORY=.*|APP_DOWNLOAD_DIRECTORY=${APP_DOWNLOAD_DIRECTORY}|" "$props"
+    [ -n "${DEFAULT_APP_STORAGE_PATH}" ] && sed -i "s|^DEFAULT_APP_STORAGE_PATH=.*|DEFAULT_APP_STORAGE_PATH=${DEFAULT_APP_STORAGE_PATH}|" "$props"
+}
+
 do_install() {
         install -d ${D}${systemd_unitdir}/system
 
@@ -41,6 +51,8 @@ do_install() {
 
         # Provide the OEM/SoC device.properties
         install -m 0644 ${S}/etc/device-vendor.properties ${D}${sysconfdir}
+        # Update the properties to match with the build configuration.
+        update_device_properties
 
         # Default RCU ctrlm_config.json configuration file.
         install -d ${D}${sysconfdir}/vendor/input


### PR DESCRIPTION
Reason for Change: add support in recipe to update the PROPERTIES based on build configuration.
Validation details:
```bash
VM2[06/Apr|15:06:48]raspberrypi4-64-rdke-vendor$ ar -x lib32-sysint-soc_1.1.13-r0_raspberrypi4-64-rdke-vendor.ipk
VM2[06/Apr|15:06:55]raspberrypi4-64-rdke-vendor$ tar -xf data.tar.xz
VM2[06/Apr|15:06:59]raspberrypi4-64-rdke-vendor$ file etc/device-vendor.properties
etc/device-vendor.properties: ASCII text
VM2[06/Apr|15:07:05]raspberrypi4-64-rdke-vendor$ cat -A etc/device-vendor.properties
DEVICE_NAME=RDKERPi4$
BOX_TYPE=DefaultBoxType$
MANUFACTURE=RaspberryPi$
MFG_NAME=RaspberryPi4$
# MODEL_NUM should case match with OTA name.$
MODEL_NUM=RPI4$
FRIENDLY_ID=RDKERPi4$
COMMUNITY_BUILDS=true$
# RDKFWUpgrader required properties$
DIFW_PATH=/opt/ota-dlpath/$
RDK_PROFILE=STB$
SOC=Broadcom$
HDD_APP_MOUNT_PATH=/opt/dac_apps$
DAC_APP_PATH=/test/opt/dac_apps/apps$
APP_PREINSTALL_DIRECTORY=/opt/media/apps$
APP_DOWNLOAD_DIRECTORY=/test/opt/CDL/$
DEFAULT_APP_STORAGE_PATH=/test/opt/persistent/storageManager$
VM2[06/Apr|15:07:08]raspberrypi4-64-rdke-vendor$
VM2[06/Apr|15:10:55]raspberrypi4-64-rdke-vendor$ cat etc/device-vendor.properties
DEVICE_NAME=RDKERPi4
BOX_TYPE=DefaultBoxType
MANUFACTURE=RaspberryPi
MFG_NAME=RaspberryPi4
# MODEL_NUM should case match with OTA name.
MODEL_NUM=RPI4
FRIENDLY_ID=RDKERPi4
COMMUNITY_BUILDS=true
# RDKFWUpgrader required properties
DIFW_PATH=/opt/ota-dlpath/
RDK_PROFILE=STB
SOC=Broadcom
HDD_APP_MOUNT_PATH=/opt/dac_apps
DAC_APP_PATH=/test/opt/dac_apps/apps
APP_PREINSTALL_DIRECTORY=/opt/media/apps
APP_DOWNLOAD_DIRECTORY=/test/opt/CDL/
DEFAULT_APP_STORAGE_PATH=/test/opt/persistent/storageManager
VM2[06/Apr|15:10:58]raspberrypi4-64-rdke-vendor$
```