### PR TITLE
RDKMVE-2122: Consume rdkvhal-devisettings-raspberrypi release 1.3.7

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -188,8 +188,8 @@ PACKAGE_ARCH:pn-wayland-default-egl = "${VENDOR_LAYER_EXTENSION}"
 # RDKV HAL component versions
 
 # RDKV HAL component versions of raspberrypi4
-SRCREV:pn-devicesettings-hal-raspberrypi4 = "1.3.6"
-PV:pn-devicesettings-hal-raspberrypi4 = "1.3.6"
+SRCREV:pn-devicesettings-hal-raspberrypi4 = "1.3.7"
+PV:pn-devicesettings-hal-raspberrypi4 = "1.3.7"
 PR:pn-devicesettings-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-devicesettings-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 


### PR DESCRIPTION
Reason for change: Fixes a tr69hostif crash that occurred when the dynamically loaded dshal library was unloaded and its thread exited, triggering a TLS destructor