### PR TITLE
RDKMVE-2768: Allow the function to pass the L2 test case even when the HDMI cable is not connected.

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -189,7 +189,7 @@ PACKAGE_ARCH:pn-wayland-default-egl = "${VENDOR_LAYER_EXTENSION}"
 
 # RDKV HAL component versions of raspberrypi4
 SRCREV:pn-devicesettings-hal-raspberrypi4 = "1.4.5"
-PV:pn-devicesettings-hal-raspberrypi4 = "1.4.4"
+PV:pn-devicesettings-hal-raspberrypi4 = "1.4.5"
 PR:pn-devicesettings-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-devicesettings-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 

--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -188,7 +188,7 @@ PACKAGE_ARCH:pn-wayland-default-egl = "${VENDOR_LAYER_EXTENSION}"
 # RDKV HAL component versions
 
 # RDKV HAL component versions of raspberrypi4
-SRCREV:pn-devicesettings-hal-raspberrypi4 = "1.4.4"
+SRCREV:pn-devicesettings-hal-raspberrypi4 = "1.4.5"
 PV:pn-devicesettings-hal-raspberrypi4 = "1.4.4"
 PR:pn-devicesettings-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-devicesettings-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"


### PR DESCRIPTION
Reason for change: Updated the revision