### PR TITLE
REFPLTV-3174: wpeframework crash happens when rebooted the device without HDMI.

### DIFF
--- a/recipes-graphics/westeros-soc/files/0001-REFPLTV-3174-NoHDMI-WpeFramework-crash-issue-fix.patch
+++ b/recipes-graphics/westeros-soc/files/0001-REFPLTV-3174-NoHDMI-WpeFramework-crash-issue-fix.patch
@@ -1,0 +1,172 @@
+From 7dd2a484e3f51635583d95fcecd16ae5a783c589 Mon Sep 17 00:00:00 2001
+From: smuthu065 <SundaraMuneeswaran_Muthuraj@comcast.com>
+Date: Wed, 15 Jul 2026 18:01:26 +0000
+Subject: [PATCH] REFPLTV-3174-NoHDMI-WpeFramework-crash-issue-fix
+
+---
+ westeros-gl/westeros-gl.c | 97 +++++++++++++++++++++++++++--------
+ 1 file changed, 76 insertions(+), 21 deletions(-)
+
+diff --git a/westeros-gl/westeros-gl.c b/westeros-gl/westeros-gl.c
+index e6dc21e1..36efd778 100644
+--- a/westeros-gl/westeros-gl.c
++++ b/westeros-gl/westeros-gl.c
+@@ -4624,6 +4624,38 @@ static void wstProcessUEvent( WstGLCtx *ctx )
+ }
+ #endif
+ 
++static drmModeEncoder *wstFindEncoderForCrtc( int drmFd,
++                                              drmModeRes *res,
++                                              drmModeEncoder *current,
++                                              int crtcIndex,
++                                              uint32_t crtcId )
++{
++   drmModeEncoder *encoder= 0;
++   int encoderIndex;
++
++   if ( current )
++   {
++      drmModeFreeEncoder( current );
++   }
++
++   for( encoderIndex= 0; encoderIndex < res->count_encoders; ++encoderIndex )
++   {
++      encoder= drmModeGetEncoder( drmFd, res->encoders[encoderIndex] );
++      if ( encoder )
++      {
++         if ( encoder->possible_crtcs & (1 << crtcIndex) )
++         {
++            encoder->crtc_id= crtcId;
++            break;
++         }
++         drmModeFreeEncoder( encoder );
++         encoder= 0;
++      }
++   }
++
++   return encoder;
++}
++
+ static WstGLCtx *wstInitCtx( void )
+ {
+    WstGLCtx *ctx= 0;
+@@ -4834,6 +4866,10 @@ static WstGLCtx *wstInitCtx( void )
+          ERROR("wstInitCtx: failed to get resources from card (%s)", card);
+          goto exit;
+       }
++      INFO("wstInitCtx: resources connectors=%d encoders=%d crtcs=%d",
++         res->count_connectors,
++         res->count_encoders,
++         res->count_crtcs);
+       for( i= 0; i < res->count_connectors; ++i )
+       {
+          conn= drmModeGetConnector( ctx->drmFd, res->connectors[i] );
+@@ -4875,27 +4911,37 @@ static WstGLCtx *wstInitCtx( void )
+          uint32_t crtcId= 0;
+          bool found= false;
+          ctx->enc= drmModeGetEncoder(ctx->drmFd, res->encoders[i]);
++         
++         if ( res->count_crtcs > res->count_encoders ) {
++            WARNING("wstInitCtx: count_crtcs(%d) > count_encoders(%d)",
++                    res->count_crtcs,
++                    res->count_encoders);
++         }
++
+          if ( ctx->enc && conn && (ctx->enc->encoder_id == conn->encoder_id) )
+          {
+             found= true;
+             break;
+          }
++         
++         if ( !ctx->enc ) {
++            continue; 
++         }
++         
+          for( j= 0; j < res->count_crtcs; j++ )
+          {
+             if ( ctx->enc->possible_crtcs & (1 << j))
+             {
+                crtcId= res->crtcs[j];
+-               for( k= 0; k < res->count_crtcs; k++ )
++               ctx->enc= wstFindEncoderForCrtc( ctx->drmFd,
++                                                res,
++                                                ctx->enc,
++                                                j,
++                                                crtcId );
++               if ( ctx->enc )
+                {
+-                  if ( res->crtcs[k] == crtcId )
+-                  {
+-                     drmModeFreeEncoder( ctx->enc );
+-                     ctx->enc= drmModeGetEncoder(ctx->drmFd, res->encoders[k]);
+-                     ctx->enc->crtc_id= crtcId;
+-                     DEBUG("got enc %p crtc id %d", ctx->enc, crtcId);
+-                     found= true;
+-                     break;
+-                  }
++                  DEBUG("got enc %p crtc id %d", ctx->enc, crtcId);
++                  found= true;
+                }
+                if ( found )
+                {
+@@ -4908,6 +4954,9 @@ static WstGLCtx *wstInitCtx( void )
+             drmModeFreeEncoder( ctx->enc );
+             ctx->enc= 0;
+          }
++         else{
++            break;
++         }
+       }
+       if ( ctx->enc )
+       {
+@@ -5400,23 +5449,26 @@ static void wstUpdateCtx( WstGLCtx *ctx )
+                   found= true;
+                   break;
+                }
++
++               if ( !ctx->enc ) {
++                  continue;
++               }
++
+                for( j= 0; j < res->count_crtcs; j++ )
+                {
+                   if ( ctx->enc->possible_crtcs & (1 << j))
+                   {
+                      crtcId= res->crtcs[j];
+-                     for( k= 0; k < res->count_crtcs; k++ )
+-                     {
+-                        if ( res->crtcs[k] == crtcId )
+-                        {
+-                           drmModeFreeEncoder( ctx->enc );
+-                           ctx->enc= drmModeGetEncoder(ctx->drmFd, res->encoders[k]);
+-                           ctx->enc->crtc_id= crtcId;
+-                           DEBUG("got enc %p crtc id %d", ctx->enc, crtcId);
+-                           found= true;
+-                           break;
+-                        }
++                     ctx->enc= wstFindEncoderForCrtc( ctx->drmFd,
++                                                      res,
++                                                      ctx->enc,
++                                                      j,
++                                                      crtcId );
++                     if ( ctx->enc ) {
++                        DEBUG("got enc %p crtc id %d", ctx->enc, crtcId);
++                        found= true;
+                      }
++                     
+                      if ( found )
+                      {
+                         break;
+@@ -5428,6 +5480,9 @@ static void wstUpdateCtx( WstGLCtx *ctx )
+                   drmModeFreeEncoder( ctx->enc );
+                   ctx->enc= 0;
+                }
++               else {
++                  break;
++               }
+             }
+ 
+             if ( ctx->haveAtomic )
+-- 
+2.44.4
+

--- a/recipes-graphics/westeros-soc/westeros-soc-drm.bb
+++ b/recipes-graphics/westeros-soc/westeros-soc-drm.bb
@@ -35,6 +35,7 @@ inherit autotools pkgconfig
 COMPATIBLE_MACHINE = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '(.*)', 'null', d)}"
 
 SRC_URI += "file://set_and_get_resolution.patch"
+SRC_URI += "file://0001-REFPLTV-3174-NoHDMI-WpeFramework-crash-issue-fix.patch"
 
 # incase if enabled in bb file, it should be removed for Rpi
 CFLAGS:remove = "${@bb.utils.contains('MACHINE_FEATURES', 'vc4graphics', '-DWESTEROS_GL_NO_PLANES', '', d)}"


### PR DESCRIPTION
**Reason for change:** WpeFramework Crash issue fix on Westeros-soc-drm component.
**Test Procedure:** Build and verify.
**Risks:** High.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com