### PR TITLE
RDKMVE-2374: Update tag to 1.4.7

### DIFF
--- a/conf/include/vendor_pkg_versions.inc
+++ b/conf/include/vendor_pkg_versions.inc
@@ -188,8 +188,8 @@ PACKAGE_ARCH:pn-wayland-default-egl = "${VENDOR_LAYER_EXTENSION}"
 # RDKV HAL component versions
 
 # RDKV HAL component versions of raspberrypi4
-SRCREV:pn-devicesettings-hal-raspberrypi4 = "1.4.6"
-PV:pn-devicesettings-hal-raspberrypi4 = "1.4.6"
+SRCREV:pn-devicesettings-hal-raspberrypi4 = "1.4.7"
+PV:pn-devicesettings-hal-raspberrypi4 = "1.4.7"
 PR:pn-devicesettings-hal-raspberrypi4 = "r0"
 PACKAGE_ARCH:pn-devicesettings-hal-raspberrypi4 = "${VENDOR_LAYER_EXTENSION}"
 


### PR DESCRIPTION
Reason for change : Update tag to 1.4.7
Test Procedure : Build is successful
Priority : Unprioritized
Risks : None