### PR TITLE
RDKMVE-2867: Enable cgroup v2 boot parameter

### DIFF
--- a/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,6 +1,6 @@
 do_compile:append() {
    if ${@bb.utils.contains('DISTRO_FEATURES', 'DOBBY_CONTAINERS', 'true', 'false', d)}; then
         sed -i 's/[[:space:]]*$//g' ${WORKDIR}/cmdline.txt
-        sed -i 's/$/ cgroup_enable=memory cgroup_memory=1/' ${WORKDIR}/cmdline.txt
+        sed -i 's/$/ cgroup_enable=memory cgroup_memory=1 systemd.unified_cgroup_hierarchy=1/' ${WORKDIR}/cmdline.txt
    fi
 }


### PR DESCRIPTION
Summary:
- Added systemd.unified_cgroup_hierarchy=1 to Raspberry Pi boot arguments.

Changes:
- Updated boot configuration generation to append the cgroup v2 boot parameter.

Validation:
- Verified the updated boot configuration contains systemd.unified_cgroup_hierarchy=1.
- Rebuilt the image successfully.
- Validated the generated boot arguments through the build flow.